### PR TITLE
Adding margin b/w "Contest rows"

### DIFF
--- a/src/app/components/ContestTable.tsx
+++ b/src/app/components/ContestTable.tsx
@@ -159,13 +159,13 @@ const ContestRow = ({ contest }: { contest: Contest }) => {
 
   return (
     <tr
-      className={`${getRowClass()} flex rounded-lg my-3`} 
+      className={getRowClass()}
       key={contest.url}
       style={{
         transition: "all .15s ease",
       }}
     >
-      <td className="py-2 px-4 border-separate">
+      <td className="py-2 px-4 border-separate rounded-lg">
         <a
           href={contest.url}
           target="_blank"
@@ -180,14 +180,12 @@ const ContestRow = ({ contest }: { contest: Contest }) => {
         >
           {contest.name}
         </a>
-        
         <div className="text-sm">
           {formatDate(contest.start_time)} <br />
           {formatDate(contest.end_time)}
         </div>
       </td>
     </tr>
-    
   );
 };
 
@@ -223,7 +221,7 @@ const ContestsList = ({
       ) : (
         <div className="overflow-x-auto">
           <table className="w-full shadow-lg border-none mt-4">
-            <tbody className="my-3">
+            <tbody>
               {contestsData.map((contest) => (
                 <ContestRow key={contest.url} contest={contest} />
               ))}

--- a/src/app/components/ContestTable.tsx
+++ b/src/app/components/ContestTable.tsx
@@ -159,13 +159,13 @@ const ContestRow = ({ contest }: { contest: Contest }) => {
 
   return (
     <tr
-      className={getRowClass()}
+      className={`${getRowClass()} flex rounded-lg my-3`} 
       key={contest.url}
       style={{
         transition: "all .15s ease",
       }}
     >
-      <td className="py-2 px-4 border-separate rounded-lg">
+      <td className="py-2 px-4 border-separate">
         <a
           href={contest.url}
           target="_blank"
@@ -180,12 +180,14 @@ const ContestRow = ({ contest }: { contest: Contest }) => {
         >
           {contest.name}
         </a>
+        
         <div className="text-sm">
           {formatDate(contest.start_time)} <br />
           {formatDate(contest.end_time)}
         </div>
       </td>
     </tr>
+    
   );
 };
 
@@ -221,7 +223,7 @@ const ContestsList = ({
       ) : (
         <div className="overflow-x-auto">
           <table className="w-full shadow-lg border-none mt-4">
-            <tbody>
+            <tbody className="my-3">
               {contestsData.map((contest) => (
                 <ContestRow key={contest.url} contest={contest} />
               ))}

--- a/src/app/components/PostMenu.tsx
+++ b/src/app/components/PostMenu.tsx
@@ -1,11 +1,11 @@
 import React from "react";
-import Title from "./Title";
+import Tittle from "./Tittle";
 import BlogPost from "./BlogPost";
 
 function PostMenu() {
   return (
     <div className="relative h-36 lg:h-48 border-t border-gray-200 bg-gray-50">
-      <Title
+      <Tittle
         title="Blog"
         desc="A collection of my thoughts and writings."
       />

--- a/src/app/components/PostMenu.tsx
+++ b/src/app/components/PostMenu.tsx
@@ -1,11 +1,11 @@
 import React from "react";
-import Tittle from "./Tittle";
+import Title from "./Title";
 import BlogPost from "./BlogPost";
 
 function PostMenu() {
   return (
     <div className="relative h-36 lg:h-48 border-t border-gray-200 bg-gray-50">
-      <Tittle
+      <Title
         title="Blog"
         desc="A collection of my thoughts and writings."
       />

--- a/src/app/components/Title.tsx
+++ b/src/app/components/Title.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-function Tittle({title,desc}:{title:string,desc:string,
+function Title({title,desc}:{title:string,desc:string,
 }) {
   return (
     <div className="absolute inset-0 flex justify-center items-center h-36 opacity-90 lg:h-48 title">
@@ -18,4 +18,4 @@ function Tittle({title,desc}:{title:string,desc:string,
   );
 }
 
-export default Tittle;
+export default Title;

--- a/src/app/components/Tittle.tsx
+++ b/src/app/components/Tittle.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-function Title({title,desc}:{title:string,desc:string,
+function Tittle({title,desc}:{title:string,desc:string,
 }) {
   return (
     <div className="absolute inset-0 flex justify-center items-center h-36 opacity-90 lg:h-48 title">
@@ -18,4 +18,4 @@ function Title({title,desc}:{title:string,desc:string,
   );
 }
 
-export default Title;
+export default Tittle;


### PR DESCRIPTION
What does this PR do :

1. Added margin between contest rows
    - added `flex` as a class as table was not allowing to add margins.

<img width="479" alt="Screenshot 2023-09-15 080539" src="https://github.com/Ayushpanditmoto/projectshub/assets/89855847/219aa8ce-586a-409c-b390-c431562ec369">

   -after adding margin

<img width="468" alt="Screenshot 2023-09-15 080603" src="https://github.com/Ayushpanditmoto/projectshub/assets/89855847/c7d21843-d1f9-48d1-bcbd-285e99b5948f">

2. Fixed a typo, "Title"

Added comments in changes also.