### PR TITLE
Resolves #47 fetch data from official endpoint of codechef

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "autoprefixer": "10.4.14",
         "axios": "^1.5.0",
         "cheerio": "^1.0.0-rc.12",
+        "date-fns": "^2.30.0",
         "eslint": "8.45.0",
         "eslint-config-next": "13.4.10",
         "framer-motion": "^10.16.0",
@@ -1801,6 +1802,21 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA=="
+    },
+    "node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
     },
     "node_modules/debug": {
       "version": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "autoprefixer": "10.4.14",
     "axios": "^1.5.0",
     "cheerio": "^1.0.0-rc.12",
+    "date-fns": "^2.30.0",
     "eslint": "8.45.0",
     "eslint-config-next": "13.4.10",
     "framer-motion": "^10.16.0",

--- a/src/app/(routes)/api/codechef/route.js
+++ b/src/app/(routes)/api/codechef/route.js
@@ -1,0 +1,46 @@
+const axios = require("axios");
+const { format, parseISO } = require("date-fns");
+
+//function to get the current time
+const getCurrentDateTime = () => {
+  const now = new Date();
+  // Format the date as "YYYY-MM-DD HH:mm:ss"
+  const formattedDate = now.toISOString().slice(0, 19).replace("T", " ");
+  return formattedDate;
+};
+
+// function to format the date string to the desired form
+function formatDateString(inputString) {
+  const parsedDate = parseISO(inputString);
+  return format(parsedDate, "MMM dd, yyyy, h:mm a");
+}
+
+// function to fetch the contest data from the codechef
+async function scrapeContestInfo() {
+  try {
+    const res = await axios.get(
+      "https://www.codechef.com/api/list/contests/all?sort_by=START&sorting_order=asc&offset=0&mode=premium"
+    );
+    const futureContest = res.data.future_contests;
+    const contestInfo = [];
+    futureContest.forEach((element) => {
+      const contest = {
+        contest_name: element.contest_name,
+        contest_start_date: formatDateString(element.contest_start_date_iso),
+        contest_end_date: formatDateString(element.contest_end_date_iso),
+      };
+      contestInfo.push(contest);
+    });
+    return {
+      last_updated: getCurrentDateTime(),
+      data: contestInfo,
+    };
+  } catch (error) {
+    console.error("Error scraping contest information:", error);
+    return [];
+  }
+}
+
+export async function GET() {
+  return Response.json(await scrapeContestInfo());
+}


### PR DESCRIPTION
Implemented fetching data from the official endpoint of CodeChef, and returning in the form of JSON.

Located at:-
![image](https://github.com/Ayushpanditmoto/projectshub/assets/129579058/dec695f8-0e1b-4744-9c12-47c61fb6fb7d)

Returns the data in the below form:-
```
{
  last_updated: '2023-10-08 09:01:01',
  data: [
    {
      contest_name: 'Starters 103',
      contest_start_date: 'Oct 11, 2023, 8:00 PM',
      contest_end_date: 'Oct 11, 2023, 10:00 PM'
    },
    {
      contest_name: 'Starters 104',
      contest_start_date: 'Oct 18, 2023, 8:00 PM',
      contest_end_date: 'Oct 18, 2023, 10:00 PM'
    },
    {
      contest_name: 'Starters 105',
      contest_start_date: 'Oct 25, 2023, 8:00 PM',
      contest_end_date: 'Oct 25, 2023, 10:00 PM'
    }
  ]
}
```
maintaining the current format of the data. 